### PR TITLE
Prepare for Clojars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,86 @@
+version: 2.1
+
+commands:
+  setup-env:
+    steps:
+      - checkout
+      - run: cd ~/repo/stefon-core; lein with-profile -dev,+test,+ci deps
+
+executor_defaults: &executor_defaults
+  working_directory: ~/repo
+
+executors:
+  openjdk8:
+    docker:
+      - image: circleci/clojure:openjdk-8-lein-2.9.1
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m
+    <<: *executor_defaults
+  openjdk11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m --illegal-access=deny
+    <<: *executor_defaults
+
+jobs:
+  test_code:
+    description: |
+      Runs tests against given version of the JDK
+    parameters:
+      jdk_version:
+        description: Version of the JDK to test against
+        type: string
+      lein_test_command:
+        description: A Leiningen command that will run a test suite
+        type: string
+    executor: << parameters.jdk_version >>
+    steps:
+      - setup-env
+      - run:
+          command: << parameters.lein_test_command >>
+  deploy:
+    executor: openjdk8
+    steps:
+      - setup-env
+      - run:
+          name: import GPG key
+          command: echo -e "$GPG_KEY_V2" | gpg --import
+      - run:
+          name: Perform pre-release sanity check
+          command: cd ~/repo/stefon-core; lein with-profile -dev,+ci run -m nedap.ci.release-workflow.api sanity-check
+      - run:
+          name: release to JFrog
+          command: cd ~/repo/stefon-core; lein deploy
+      - run:
+          name: release to Clojars
+          command: cd ~/repo/stefon-core; lein deploy clojars
+
+test_code_filters: &test_code_filters
+  filters:
+    branches:
+      only: /.*/
+    tags:
+      only: /^v\d+\.\d+\.\d+(-alpha\d+)?$/
+
+workflows:
+  version: 2.1
+  CircleCI:
+    jobs:
+      - test_code:
+          name: "Ensure artifact isolation, inform of boxed math"
+          jdk_version: openjdk8
+          lein_test_command: cd ~/repo/stefon-core; lein with-profile -dev,+check check
+          context: JFrog
+          <<: *test_code_filters
+      - deploy:
+          context: JFrog
+          requires:
+            - "Ensure artifact isolation, inform of boxed math"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+(-alpha\d+)?$/

--- a/stefon-core/README.md
+++ b/stefon-core/README.md
@@ -1,0 +1,5 @@
+## Installation
+
+```clojure
+[com.nedap.staffing-solutions/stefon "0.5.1"]
+```

--- a/stefon-core/README.md
+++ b/stefon-core/README.md
@@ -1,5 +1,5 @@
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/stefon "0.5.1"]
+[com.nedap.staffing-solutions/stefon "0.5.2-alpha1"]
 ```

--- a/stefon-core/project.clj
+++ b/stefon-core/project.clj
@@ -1,18 +1,29 @@
 (defproject com.nedap.staffing-solutions/stefon "0.5.1"
+
   :description "Asset pipeline ring middleware"
+
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+
   :url "http://github.com/circleci/stefon"
+
+  :signing {:gpg-key "releases-staffingsolutions@nedap.com"}
+
   :repositories {"releases" {:url      "https://nedap.jfrog.io/nedap/staffing-solutions/"
                              :username :env/artifactory_user
                              :password :env/artifactory_pass}}
-  :deploy-repositories [["releases" {:url           "https://nedap.jfrog.io/nedap/staffing-solutions/"
-                                     :sign-releases false}]]
+
   :repository-auth {#"https://nedap.jfrog\.io/nedap/staffing-solutions/"
                     {:username :env/artifactory_user
                      :password :env/artifactory_pass}}
-  :dependencies [[ring/ring-core "1.2.0"]
+
+  :deploy-repositories {"clojars" {:url      "https://clojars.org/repo"
+                                   :username :env/clojars_user
+                                   :password :env/clojars_pass}}
+
+  :dependencies [[ring/ring-core "1.5.0"]
                  [clj-time "0.4.4"]
+                 [org.clojure/clojure "1.10.1"]
                  [org.clojure/core.incubator "0.1.1"]
                  [org.clojure/tools.logging "0.2.3"]
                  [cheshire "4.0.0"]
@@ -21,6 +32,27 @@
                  [clj-v8 "0.1.4"]
                  [clj-v8-native "0.1.4"]
                  [pathetic "0.5.1"]]
-  :profiles {:dev {:dependencies [[ring-mock "0.1.4"]
-                                  [org.clojure/clojure "1.5.1"]
-                                  [bond "0.2.5" :exclusions [org.clojure/clojure]]]}})
+
+  :profiles {:dev        {:dependencies [[bond "0.2.5" :exclusions [org.clojure/clojure]]]}
+             :check      {:global-vars {*unchecked-math* :warn-on-boxed
+                                        ;; avoid warnings that cannot affect production:
+                                        *assert*         false}}
+
+             ;; some settings recommended for production applications.
+             ;; You may also add :test, but beware of doing that if using this profile while running tests in CI.
+             :production {:jvm-opts    ["-Dclojure.compiler.elide-meta=[:doc :file :author :line :column :added :deprecated :nedap.speced.def/spec :nedap.speced.def/nilable]"
+                                        "-Dclojure.compiler.direct-linking=true"]
+                          :global-vars {*assert* false}}
+
+             ;; this profile is necessary since JDK >= 11 removes XML Bind, used by Jackson, which is a very common dep.
+             :jdk11      {:dependencies [[javax.xml.bind/jaxb-api "2.3.1"]
+                                         [org.glassfish.jaxb/jaxb-runtime "2.3.1"]]}
+
+             :test       {:dependencies [[com.nedap.staffing-solutions/utils.test "1.6.2"]
+                                         [ring-mock "0.1.4"]]
+                          :jvm-opts     ["-Dclojure.core.async.go-checking=true"
+                                         "-Duser.language=en-US"]}
+
+             :ci         {:jvm-opts     ["-Dclojure.main.report=stderr"]
+                          :global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
+                          :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.7.0-alpha3"]]}})

--- a/stefon-core/project.clj
+++ b/stefon-core/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/stefon "0.5.1"
+(defproject com.nedap.staffing-solutions/stefon "0.5.2-alpha1"
 
   :description "Asset pipeline ring middleware"
 


### PR DESCRIPTION
Our fork, as of today merely consists of https://github.com/nedap/stefon/commit/c3dd5dc997114b8fd68b42d7e460624d34399b4b

This PR prepares a Clojars setup so that we can enjoy that commit from any consumer.

It's the last step needed so that our Lein template can emit usable webapps needing no Nedap repo auth.